### PR TITLE
Bump citation metadata to v0.6.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,12 +12,12 @@ authors:
   - family-names: "De Clerck"
     given-names: "Bart"
     orcid: "https://orcid.org/0000-0002-9718-260X" 
-version: "0.5.2"
+version: "0.6.0"
 license: MIT
 repository-code: "https://github.com/B4rtDC/MaxEntropyGraphs.jl"
 url: "https://b4rtdc.github.io/MaxEntropyGraphs.jl/dev/"
 doi: "10.5281/zenodo.8314609"          # Zenodo concept DOI (all versions; always resolves to the latest release)
-date-released: "2026-07-04"
+date-released: "2026-07-05"
 keywords:
   - Julia
   - network science

--- a/README.MD
+++ b/README.MD
@@ -65,7 +65,7 @@ When using this package in your scientific research, please cite it. The canonic
   title        = {{MaxEntropyGraphs.jl}},
   year         = {2026},
   publisher    = {Zenodo},
-  version      = {v0.5.1},
+  version      = {v0.6.0},
   doi          = {10.5281/zenodo.8314609},
   url          = {https://github.com/B4rtDC/MaxEntropyGraphs.jl}
 }

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -97,7 +97,7 @@ When using this package for your scientific research please consider citing it; 
   title        = {{MaxEntropyGraphs.jl}},
   year         = {2026},
   publisher    = {Zenodo},
-  version      = {v0.5.1},
+  version      = {v0.6.0},
   doi          = {10.5281/zenodo.8314609},
   url          = {https://github.com/B4rtDC/MaxEntropyGraphs.jl}
 }


### PR DESCRIPTION
Aligns the citation metadata with the released code version (`Project.toml` is already at `0.6.0` after #7).

- `CITATION.cff`: `version` 0.5.2 → 0.6.0, `date-released` → 2026-07-05.
- `README.MD` and `docs/src/index.md`: the `@software` BibTeX `version` v0.5.1 → v0.6.0 (they had not been bumped for 0.5.2 either).

The Zenodo **concept** DOI (`10.5281/zenodo.8314609`) is unchanged — it always resolves to the latest release. A version-specific Zenodo archive DOI for v0.6.0 is created separately, after tagging.

Note: `date-released` assumes the v0.6.0 tag is cut today; adjust if the release slips.