### PR TITLE
Release 0.5.3 (additive: UECM + CReM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.6.0
+## v0.5.3
 
 Weighted, undirected models brought to full parity with the binary trio (UBCM/DBCM/BiCM).
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
   - family-names: "De Clerck"
     given-names: "Bart"
     orcid: "https://orcid.org/0000-0002-9718-260X" 
-version: "0.6.0"
+version: "0.5.3"
 license: MIT
 repository-code: "https://github.com/B4rtDC/MaxEntropyGraphs.jl"
 url: "https://b4rtdc.github.io/MaxEntropyGraphs.jl/dev/"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MaxEntropyGraphs"
 uuid = "0bc52ce7-e54a-4624-bf8b-683aa79224c9"
-version = "0.6.0"
+version = "0.5.3"
 authors = ["Bart De Clerck"]
 
 [deps]

--- a/README.MD
+++ b/README.MD
@@ -65,7 +65,7 @@ When using this package in your scientific research, please cite it. The canonic
   title        = {{MaxEntropyGraphs.jl}},
   year         = {2026},
   publisher    = {Zenodo},
-  version      = {v0.6.0},
+  version      = {v0.5.3},
   doi          = {10.5281/zenodo.8314609},
   url          = {https://github.com/B4rtDC/MaxEntropyGraphs.jl}
 }

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -97,7 +97,7 @@ When using this package for your scientific research please consider citing it; 
   title        = {{MaxEntropyGraphs.jl}},
   year         = {2026},
   publisher    = {Zenodo},
-  version      = {v0.6.0},
+  version      = {v0.5.3},
   doi          = {10.5281/zenodo.8314609},
   url          = {https://github.com/B4rtDC/MaxEntropyGraphs.jl}
 }


### PR DESCRIPTION
Re-labels the release as **0.5.3** instead of 0.6.0.

Adding the `UECM` and `CReM` models is **backward-compatible** — no existing API changed or was removed — so under Julia's 0.x SemVer this is a **patch** bump (`0.5.3`), not a breaking minor bump. (The General registry's AutoMerge correctly flags any `0.5 → 0.6` bump as "breaking"; `0.5.3` avoids the false signal.)

Changes `Project.toml`, `CHANGELOG.md`, `CITATION.cff`, `README.MD`, and `docs/src/index.md` from 0.6.0 → 0.5.3. No code changes. Supersedes the withdrawn 0.6.0 registration (General #160072, left blocked).